### PR TITLE
Related Works in Libraries communities records

### DIFF
--- a/assets/js/components/LibrariesConditionalFields.js
+++ b/assets/js/components/LibrariesConditionalFields.js
@@ -20,7 +20,12 @@ const severityChecks = {
     }
 }
 
-function IsLibrariesCommunity(community){
+/**
+ * Whether the given community is one of the "Libraries" communities
+ * @param {string} community - community slug
+ * @returns {boolean}
+ */
+function IsLibrariesCommunity(community) {
     return [
         'artists-books',
         'art-collection',

--- a/assets/js/components/LibrariesConditionalFields.js
+++ b/assets/js/components/LibrariesConditionalFields.js
@@ -1,0 +1,69 @@
+import {useFormikContext} from "formik"
+import React, {useState, useEffect} from "react"
+// redux store getState().deposit.editorState.selectedCommunity is the only way to know the selected community
+import {useSelector} from "react-redux"
+import {AccordionField} from "react-invenio-forms"
+import {RelatedWorksField} from "@js/invenio_rdm_records"
+import {i18next} from "@translations/invenio_app_rdm/i18next"
+// https://github.com/inveniosoftware/invenio-app-rdm/blob/master/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposit/RDMDepositForm.js
+// https://github.com/inveniosoftware/invenio-rdm-records/tree/master/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields
+
+// Config for the related works section
+const severityChecks = {
+    info: {
+        label: i18next.t("Recommendation"),
+        description: i18next.t("This check is recommended but not mandatory.")
+    },
+    error: {
+        label: i18next.t("Error"),
+        description: i18next.t("This check indicates a critical issue that must be addressed.")
+    }
+}
+
+function IsLibrariesCommunity(community){
+    return [
+        'artists-books',
+        'art-collection',
+        'capp-street',
+        'hamaguchi',
+        'libraries',
+        'mudflats',
+        'open-access',
+        'design-book-review',
+        'faculty-research']
+        .includes(community)
+}
+
+export const RelatedWorksIfLibraries = (props) => {
+    const fieldPath = "metadata.related_identifiers"
+    // we override the accordion field so we have to re-implement it here
+    // props.vocabularies contains the vocabularies from RDMDepositForm
+    const vocabularies = props.vocabularies || {}
+    const {setFieldValue} = useFormikContext()
+    const community = useSelector(state => state.deposit.editorState.selectedCommunity?.slug)
+    const [active, setActive] = useState(IsLibrariesCommunity(community))
+
+    useEffect(() => {
+        const isActive = IsLibrariesCommunity(community)
+        if (active !== isActive) {
+            setActive(isActive)
+            // clear the field value when it becomes inactive
+            if (!isActive) setFieldValue(fieldPath, [])
+        }
+    }, [community, active, fieldPath, setFieldValue])
+
+    if (!active) return null
+
+    return <AccordionField
+        includesPaths={[fieldPath]}
+        severityChecks={severityChecks}
+        active
+        label={i18next.t("Related works")}
+        id="related-works-section">
+        <RelatedWorksField
+            fieldPath={fieldPath}
+            options={vocabularies.metadata.identifiers}
+            showEmptyValue
+        />
+    </AccordionField>
+}

--- a/assets/js/components/LibrariesConditionalFields.js
+++ b/assets/js/components/LibrariesConditionalFields.js
@@ -25,7 +25,7 @@ const severityChecks = {
  * @param {string} community - community slug
  * @returns {boolean}
  */
-function IsLibrariesCommunity(community) {
+function isLibrariesCommunity(community) {
     return [
         'artists-books',
         'art-collection',
@@ -44,18 +44,8 @@ export const RelatedWorksIfLibraries = (props) => {
     // we override the accordion field so we have to re-implement it here
     // props.vocabularies contains the vocabularies from RDMDepositForm
     const vocabularies = props.vocabularies || {}
-    const {setFieldValue} = useFormikContext()
     const community = useSelector(state => state.deposit.editorState.selectedCommunity?.slug)
-    const [active, setActive] = useState(IsLibrariesCommunity(community))
-
-    useEffect(() => {
-        const isActive = IsLibrariesCommunity(community)
-        if (active !== isActive) {
-            setActive(isActive)
-            // clear the field value when it becomes inactive
-            if (!isActive) setFieldValue(fieldPath, [])
-        }
-    }, [community, active, fieldPath, setFieldValue])
+    const active = isLibrariesCommunity(community)
 
     if (!active) return null
 

--- a/assets/js/invenio_app_rdm/overridableRegistry/mapping.js
+++ b/assets/js/invenio_app_rdm/overridableRegistry/mapping.js
@@ -1,12 +1,13 @@
 /**
- * Add here all the overridden components of your app.
+ * Override Invenio React Components https://inveniordm.docs.cern.ch/operate/customize/look-and-feel/override_components/
  * Example from Zenodo:
  * https://github.com/zenodo/zenodo-rdm/blob/master/assets/js/invenio_app_rdm/overridableRegistry/mapping.js#L3
- * Find the names of overridable components in RDMDepositForm.js:
- * https://github.com/inveniosoftware/invenio-app-rdm/blob/master/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposit/RDMDepositForm.js
+ * Find the names of overridable components by running `reactOverridableEnableDevMode()` in dev tools
  * TODO we need to find a way to include the invenio_app_rdm default override (TimelineFeedHeader)
  * It's not in a JS package, is copying a bunch of files the only way?
  */
+
+import {RelatedWorksIfLibraries} from "../../components/LibrariesConditionalFields";
 
 export const overriddenComponents = {
     "InvenioAppRdm.Deposit.AccordionFieldFunding.container": () => null,
@@ -15,7 +16,7 @@ export const overriddenComponents = {
     "InvenioAppRdm.Deposit.PublisherField.container": () => null,
     "InvenioAppRdm.Deposit.AccordionFieldAlternateIdentifiers.container": () => null,
     // TODO look into conditional container that shows this for Libraries community records
-    "InvenioAppRdm.Deposit.AccordionFieldRelatedWorks.container": () => null,
+    "InvenioAppRdm.Deposit.AccordionFieldRelatedWorks.container": RelatedWorksIfLibraries,
     "InvenioAppRdm.Deposit.AccordionFieldReferences.container": () => null,
     "InvenioCommunities.CommunityProfileForm.AccordionField.MetadataFunding": () => null
 }


### PR DESCRIPTION
Closes #83. QA Prerequisites: libraries communities created, at least one record in a library community with a Related Work. Note that every migrated work will have a "new version of" relation to its VAULT record.

Testing:
 - [ ] Create a new record, Related Works should not appear
 - [ ] Select a library community, Related Works should appear
 - [ ] Find a record in a library community with a Related Work (`_exists_:metadata.related_identifiers`), edit it, Related Work should appear

Question: should we show Related Works for records which already have them? This means editing any migrated record shows the field, perhaps a distraction for users but makes it easier to remove the VAULT URL if that's desirable.
